### PR TITLE
Fix compile error when use wide characters

### DIFF
--- a/squall/squall_call.hpp
+++ b/squall/squall_call.hpp
@@ -41,14 +41,14 @@ void call_setup(HSQUIRRELVM vm, const HSQOBJECT& table,
     sq_pushobject(vm, table);
     sq_pushstring(vm, name.data(), name.length());
     if (!SQ_SUCCEEDED(sq_get(vm, -2))) {
-        throw squirrel_error("can't find such function: " + name);
+        throw squirrel_error(_SC("can't find such function: ") + name);
     }
 
     sq_remove(vm, -2);
     sq_pushobject(vm, table);
     call_setup_arg(vm, args...);
     if (!SQ_SUCCEEDED(sq_call(vm, sizeof...(args)+1, SQTrue, SQTrue))) {
-        throw squirrel_error("function call failed: " + name);
+        throw squirrel_error(_SC("function call failed: ") + name);
     }
 }
 

--- a/squall/squall_coroutine.hpp
+++ b/squall/squall_coroutine.hpp
@@ -43,7 +43,7 @@ public:
     void resume(T v) {
         validate_vm();
         detail::push(vm_, v);
-        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQTrue, SQTrue, SQTrue))) {
+        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQTrue, SQTrue, SQTrue, SQFalse))) {
             throw squirrel_error("wake up vm failed");
         }
         check_suspended();
@@ -51,7 +51,7 @@ public:
 
     void resume() {
         validate_vm();
-        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQFalse, SQTrue, SQTrue))) {
+        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQFalse, SQTrue, SQTrue, SQFalse))) {
             throw squirrel_error("wake up vm failed");
         }
         check_suspended();

--- a/squall/squall_coroutine.hpp
+++ b/squall/squall_coroutine.hpp
@@ -43,7 +43,7 @@ public:
     void resume(T v) {
         validate_vm();
         detail::push(vm_, v);
-        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQTrue, SQTrue, SQTrue, SQFalse))) {
+        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQTrue, SQTrue, SQTrue))) {
             throw squirrel_error("wake up vm failed");
         }
         check_suspended();
@@ -51,7 +51,7 @@ public:
 
     void resume() {
         validate_vm();
-        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQFalse, SQTrue, SQTrue, SQFalse))) {
+        if (!SQ_SUCCEEDED(sq_wakeupvm(vm_, SQFalse, SQTrue, SQTrue))) {
             throw squirrel_error("wake up vm failed");
         }
         check_suspended();

--- a/squall/squall_defun.hpp
+++ b/squall/squall_defun.hpp
@@ -72,18 +72,18 @@ SQInteger stub(HSQUIRRELVM vm) {
     }
     catch(std::exception& e) {
         return sq_throwerror(
-            vm, (string("error in callback: ") + e.what()).c_str());
+            vm, (string(_SC("error in callback: ")) + locale_converter::to_squall_string(e.what()).c_str()).c_str());
     }
 }
 
-template <class T> char typemask() { return '.'; }
+template <class T> SQChar typemask() { return _SC('.'); }
 
-template <> inline char typemask<decltype(nullptr)>() { return 'o'; }
-template <> inline char typemask<int>() { return 'i'; }
-template <> inline char typemask<float>() { return 'f'; }
-template <> inline char typemask<bool>() { return 'b'; }
-template <> inline char typemask<const char*>() { return 's'; }
-template <> inline char typemask<string>() { return 's'; }
+template <> inline SQChar typemask<decltype(nullptr)>() { return _SC('o'); }
+template <> inline SQChar typemask<int>() { return _SC('i'); }
+template <> inline SQChar typemask<float>() { return _SC('f'); }
+template <> inline SQChar typemask<bool>() { return _SC('b'); }
+template <> inline SQChar typemask<const SQChar*>() { return _SC('s'); }
+template <> inline SQChar typemask<string>() { return _SC('s'); }
 
 template <class... T>
 struct TypeMaskList;
@@ -121,7 +121,7 @@ void defun_global(
     const string& name, const std::function<R (T...)>& f) {
 
     sq_pushobject(vm, table);
-    defun<2>(vm, name, f, "." + TypeMaskList<T...>::doit());
+    defun<2>(vm, name, f, _SC(".") + TypeMaskList<T...>::doit());
     sq_pop(vm, 1);
 }
 

--- a/squall/squall_defvar.hpp
+++ b/squall/squall_defvar.hpp
@@ -1,10 +1,10 @@
 // 2015/01/23 Naoyuki Hirayama
 
 /*!
-	@file	  squall_defvar.hpp
-	@brief	  <概要>
+@file      squall_defvar.hpp
+@brief      <brief>
 
-	<説明>
+<description>
 */
 
 #ifndef SQUALL_DEFVAR_HPP_

--- a/squall/squall_exception.hpp
+++ b/squall/squall_exception.hpp
@@ -2,13 +2,14 @@
 #define SQUALL_EXCEPTION_HPP_
 
 #include <stdexcept>
+#include "squall_utility.hpp"
 
 namespace squall {
 
 class squirrel_error : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
-    squirrel_error(const std::string& s) : std::runtime_error(s) {}
+    squirrel_error(const string& s) : std::runtime_error(locale_converter::to_std_string(s)) {}
 };
 
 }

--- a/squall/squall_klass.hpp
+++ b/squall/squall_klass.hpp
@@ -23,7 +23,7 @@ public:
     void operator=(const Klass&&) = delete;
     
     template <class F>
-    Klass<C, Base>& func(const char* name, F f) {
+    Klass<C, Base>& func(const SQChar* name, F f) {
         func(string(name), f);
         return *this;
     }

--- a/squall/squall_klass_table.hpp
+++ b/squall/squall_klass_table.hpp
@@ -67,7 +67,7 @@ public:
         if (closed_) { return; }
 
         keeper k(vm_);
-        sq_pushroottable(vm_); // TODO: root固定になってる
+        sq_pushroottable(vm_);
         sq_pushstring(vm_, name_.c_str(), -1);
         sq_pushobject(vm_, sqclass_);
         sq_createslot(vm_, -3);
@@ -99,7 +99,7 @@ private:
             const SQChar* s;
             sq_getstring(vm, 2, &s);
             return sq_throwerror(
-                vm, ("member variable '" + string(s) + "' not found").c_str());
+                vm, (_SC("member variable '") + string(s) + _SC("' not found")).c_str());
         }
 		
         sq_push(vm, 1);
@@ -118,7 +118,7 @@ private:
             const SQChar* s;
             sq_getstring(vm, 2, &s);
             return sq_throwerror(
-                vm, ("member variable '" + string(s) + "' not found").c_str());
+                vm, (_SC("member variable '") + string(s) + _SC("' not found")).c_str());
         }
 		
         sq_push(vm, 1);

--- a/squall/squall_stack_operation.hpp
+++ b/squall/squall_stack_operation.hpp
@@ -135,22 +135,22 @@ template <FetchContext> string fetch_context_string();
 
 template <>
 inline string fetch_context_string<FetchContext::Argument>() {
-    return "argument";
+    return _SC("argument");
 }
 
 template <>
 inline string fetch_context_string<FetchContext::ReturnValue>() {
-    return "return value";
+    return _SC("return value");
 }
 
 template <>
 inline string fetch_context_string<FetchContext::TableEntry>() {
-    return "table entry";
+    return _SC("table entry");
 }
 
 template <>
 inline string fetch_context_string<FetchContext::YieldedValue>() {
-    return "yielded value";
+    return _SC("yielded value");
 }
 
 template <FetchContext FC>
@@ -158,8 +158,8 @@ void check_argument_type(HSQUIRRELVM vm, SQInteger index, SQObjectType t) {
     SQObjectType at = sq_gettype(vm, index);
     if (at != t) {
         throw squirrel_error(
-            fetch_context_string<FC>() + " must be " + get_type_text(t) +
-            ", actual value is " + get_type_text(at));
+            fetch_context_string<FC>() + _SC(" must be ") + get_type_text(t) +
+            _SC(", actual value is ") + get_type_text(at));
     }
 }
 

--- a/squall/squall_utility.hpp
+++ b/squall/squall_utility.hpp
@@ -3,10 +3,41 @@
 
 #include <squirrel.h>
 #include <string>
+#include <codecvt>
+#include <type_traits>
 
 namespace squall {
 
 using string = std::basic_string<SQChar>;
+
+namespace detail {
+    template<class T>
+    struct _locale_converter {
+        template<class U = T, typename std::enable_if<std::is_same<U, char>::value, std::nullptr_t>::type = nullptr>
+        static const std::string& to_std_string(const string& str) {
+            return str;
+        }
+
+        template<class U = T, typename std::enable_if<std::is_same<U, wchar_t>::value, std::nullptr_t>::type = nullptr>
+        static const std::string& to_std_string(const string& str) {
+            std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+            return converter.to_bytes(str);
+        }
+
+        template<class U = T, typename std::enable_if<std::is_same<U, char>::value, std::nullptr_t>::type = nullptr>
+        static const string& to_squall_string(const std::string& str) {
+            return str;
+        }
+
+        template<class U = T, typename std::enable_if<std::is_same<U, wchar_t>::value, std::nullptr_t>::type = nullptr>
+        static const string& to_squall_string(const std::string& str) {
+            std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+            return converter.from_bytes(str);
+        }
+    };
+}
+
+using locale_converter = detail::_locale_converter<SQChar>;
 
 ////////////////////////////////////////////////////////////////
 // stack keeper
@@ -77,21 +108,21 @@ unwrap_type(T x) { return typename unwrapped_type<T>::value_type(x); }
 inline
 string get_type_text(SQObjectType t) {
     switch(t) {
-        case OT_NULL:           return "null";        
-        case OT_INTEGER:        return "integer";
-        case OT_FLOAT:          return "float";
-        case OT_STRING:         return "string";
-        case OT_TABLE:          return "table";
-        case OT_ARRAY:          return "array";
-        case OT_USERDATA:       return "userdata";
-        case OT_CLOSURE:        return "closurefunction";    
-        case OT_NATIVECLOSURE:  return "native closureC function";
-        case OT_GENERATOR:      return "generator";
-        case OT_USERPOINTER:    return "userpointer";
-        case OT_CLASS:          return "class";
-        case OT_INSTANCE:       return "instance";
-        case OT_WEAKREF:        return "weak reference";
-        default:                return "unknown";
+        case OT_NULL:           return _SC("null");
+        case OT_INTEGER:        return _SC("integer");
+        case OT_FLOAT:          return _SC("float");
+        case OT_STRING:         return _SC("string");
+        case OT_TABLE:          return _SC("table");
+        case OT_ARRAY:          return _SC("array");
+        case OT_USERDATA:       return _SC("userdata");
+        case OT_CLOSURE:        return _SC("closurefunction");
+        case OT_NATIVECLOSURE:  return _SC("native closureC function");
+        case OT_GENERATOR:      return _SC("generator");
+        case OT_USERPOINTER:    return _SC("userpointer");
+        case OT_CLASS:          return _SC("class");
+        case OT_INSTANCE:       return _SC("instance");
+        case OT_WEAKREF:        return _SC("weak reference");
+        default:                return _SC("unknown");
     }
 }
 

--- a/squall/squall_utility.hpp
+++ b/squall/squall_utility.hpp
@@ -19,7 +19,7 @@ namespace detail {
         }
 
         template<class U = T, typename std::enable_if<std::is_same<U, wchar_t>::value, std::nullptr_t>::type = nullptr>
-        static const std::string& to_std_string(const string& str) {
+        static std::string to_std_string(const string& str) {
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             return converter.to_bytes(str);
         }
@@ -30,7 +30,7 @@ namespace detail {
         }
 
         template<class U = T, typename std::enable_if<std::is_same<U, wchar_t>::value, std::nullptr_t>::type = nullptr>
-        static const string& to_squall_string(const std::string& str) {
+        static string to_squall_string(const std::string& str) {
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             return converter.from_bytes(str);
         }

--- a/squall/squall_vm.hpp
+++ b/squall/squall_vm.hpp
@@ -38,20 +38,26 @@ public:
         HSQUIRRELVM vm = handle();
         sq_setforeignptr(vm, &klass_table_);
 
-        // root table取得
         sq_pushroottable(vm);
         sq_getstackobj(vm, -1, &root_);
         sq_pop(vm, -1);
 
         root_table_.reset(new TableBase(vm, root_));
     }
-    ~VM() { sq_setforeignptr(handle(), 0); }
+    ~VM() { sq_setforeignptr(handle(), 0); } 
 
-    template <class R, class... T>
-
-    R call(const string& name, T... args) {
+#ifdef _MSC_VER
+    //Avoiding Visual C ++ bugs
+    template <class R, typename... Args>
+    R call(const string& name, Args... args) {
+        return root_table_.get()->call<R>(name, args...);
+    }
+#else
+    template <class R, typename... Args>
+    R call(const string& name, Args... args) {
         return root_table_->call<R>(name, args...);
     }
+#endif
 
     template <class F>
     void defun(const string& name, F f) {

--- a/squall/squall_vmstd.hpp
+++ b/squall/squall_vmstd.hpp
@@ -38,7 +38,7 @@ class VMStd : public VM {
 public:
     VMStd(int stack_size = 1024) : VM(stack_size) {
         sqstd_seterrorhandlers(handle());
-        sq_setprintfunc(handle(), &detail::pf<SQChar>, &detail::pf<SQChar>);
+        sq_setprintfunc(handle(), &detail::pf<SQChar>);
     }
 
     void dofile(const SQChar* filename) {
@@ -52,13 +52,13 @@ public:
     void dostring(const SQChar* source) {
         keeper k(handle());
         if (!SQ_SUCCEEDED(sq_compilebuffer(handle(), source, static_cast<int>(scstrlen(source) * sizeof(SQChar)), _SC("dostring"), 1))) {
-            throw squirrel_error("dostring failed");
+            throw squirrel_error("dostring compile failed");
         }
 
         sq_pushroottable(handle());
 
         if (!SQ_SUCCEEDED(sq_call(handle(), 1, SQFalse, SQTrue))) {
-            throw squirrel_error("dostring failed");
+            throw squirrel_error("dostring call failed");
         }
     }
 

--- a/squall/squall_vmstd.hpp
+++ b/squall/squall_vmstd.hpp
@@ -38,7 +38,7 @@ class VMStd : public VM {
 public:
     VMStd(int stack_size = 1024) : VM(stack_size) {
         sqstd_seterrorhandlers(handle());
-        sq_setprintfunc(handle(), &detail::pf<SQChar>);
+        sq_setprintfunc(handle(), &detail::pf<SQChar>, &detail::pf<SQChar>);
     }
 
     void dofile(const SQChar* filename) {


### PR DESCRIPTION
Squall library occurs compile error when use wide characters with Visual Studio 2017.
This PR fixes all.